### PR TITLE
Fix tsconfig baseUrl formatting

### DIFF
--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -13,7 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": "."
+    "baseUrl": ".",
     "paths":{
       "@/":["./"]
     }


### PR DESCRIPTION
## Summary
- add missing comma after baseUrl in tsconfig to separate paths configuration

## Testing
- npm run build *(fails: module resolution error for @/lib/data, but TS1005 no longer occurs)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe5d4e5648328931ff76a3a265046