### PR TITLE
Make base path configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Deploying under a sub-path (e.g. GitHub Pages)
+
+By default the app assumes it is deployed from the domain root (as on Vercel).
+If you need to serve the static export from a sub-path, set the `NEXT_PUBLIC_BASE_PATH`
+environment variable before building, for example:
+
+```bash
+NEXT_PUBLIC_BASE_PATH=/dem-fre.chat npm run build
+```
+
+This will ensure the generated assets use the correct base path.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,24 @@
 import type { NextConfig } from "next";
 
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH?.trim();
+const normalizedBasePath =
+  rawBasePath && rawBasePath !== "/"
+    ? rawBasePath.replace(/\/+$/, "")
+    : "";
+
 const nextConfig: NextConfig = {
   /* config options here */
-  output: 'export',
+  output: "export",
   trailingSlash: true,
   images: {
-    unoptimized: true
+    unoptimized: true,
   },
-  basePath: process.env.NODE_ENV === 'production' ? '/dem-fre.chat' : '',
-  assetPrefix: process.env.NODE_ENV === 'production' ? '/dem-fre.chat/' : '',
+  ...(normalizedBasePath
+    ? {
+        basePath: normalizedBasePath,
+        assetPrefix: `${normalizedBasePath}/`,
+      }
+    : {}),
 };
 
 export default nextConfig;

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,9 +1,6 @@
 export default function LoginPage() {
   return (
     <main>
-      {/* 引入全局样式 */}
-      <link rel="stylesheet" href="/css/style.css" />
-      
       <div className="login-container">
         <h2>用户登录</h2>
         <form id="login-form">


### PR DESCRIPTION
## Summary
- allow configuring the Next.js base path through a NEXT_PUBLIC_BASE_PATH env var so assets resolve correctly on Vercel
- document how to set the base path when deploying under a sub-path
- remove a redundant stylesheet link from the login page to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd55861a4c8328936636eeb2e70fcf