### PR TITLE
Revamp login layout and add guest posting sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Deploying under a sub-path (e.g. GitHub Pages)
+
+By default the app assumes it is deployed from the domain root (as on Vercel).
+If you need to serve the static export from a sub-path, set the `NEXT_PUBLIC_BASE_PATH`
+environment variable before building, for example:
+
+```bash
+NEXT_PUBLIC_BASE_PATH=/dem-fre.chat npm run build
+```
+
+This will ensure the generated assets use the correct base path.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,24 @@
 import type { NextConfig } from "next";
 
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH?.trim();
+const normalizedBasePath =
+  rawBasePath && rawBasePath !== "/"
+    ? rawBasePath.replace(/\/+$/, "")
+    : "";
+
 const nextConfig: NextConfig = {
   /* config options here */
-  output: 'export',
+  output: "export",
   trailingSlash: true,
   images: {
-    unoptimized: true
+    unoptimized: true,
   },
-  basePath: process.env.NODE_ENV === 'production' ? '/dem-fre.chat' : '',
-  assetPrefix: process.env.NODE_ENV === 'production' ? '/dem-fre.chat/' : '',
+  ...(normalizedBasePath
+    ? {
+        basePath: normalizedBasePath,
+        assetPrefix: `${normalizedBasePath}/`,
+      }
+    : {}),
 };
 
 export default nextConfig;

--- a/src/app/factions/page.tsx
+++ b/src/app/factions/page.tsx
@@ -29,6 +29,7 @@ export default function FactionsPage() {
             { href: "/#hot", label: "热帖" },
             { href: "/factions", label: "热门派别" },
             { href: "/ranking", label: "用户排行" },
+            { href: "/guest", label: "游客体验" },
           ]}
           loginHref="/login"
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -128,41 +128,256 @@ footer {
   color: #1976d2;
   font-size: 0.95rem;
 }
-.login-container {
-  max-width: 350px;
-  margin: 4rem auto;
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(25, 118, 210, 0.08);
-  padding: 2rem;
-  text-align: center;
+.auth-layout {
+  max-width: 1100px;
+  margin: 3rem auto;
+  padding: 0 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: stretch;
 }
-.login-container h2 {
-  margin-bottom: 1.5rem;
+.auth-hero {
+  background: linear-gradient(160deg, #1e88e5, #42a5f5);
+  color: #fff;
+  border-radius: 18px;
+  padding: 2.5rem 2.25rem;
+  box-shadow: 0 18px 45px rgba(25, 118, 210, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
-#login-form input {
-  width: 90%;
-  padding: 0.7rem;
-  margin-bottom: 1rem;
-  border: 1px solid #b3c6e6;
-  border-radius: 4px;
+.auth-hero h1 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin: 0;
+}
+.auth-hero p {
+  margin: 0;
+  line-height: 1.7;
   font-size: 1rem;
 }
-#login-form button {
-  width: 95%;
-  padding: 0.7rem;
+.auth-hero ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.98rem;
+}
+.auth-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.login-container {
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(25, 118, 210, 0.12);
+  padding: 2.4rem 2.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+.login-container h1,
+.login-container h2 {
+  margin: 0;
+  color: #0d47a1;
+  font-size: 1.65rem;
+}
+.login-subtitle {
+  margin: 0;
+  color: #5f7393;
+  font-size: 0.98rem;
+}
+.auth-toggle {
+  display: inline-flex;
+  border-radius: 999px;
+  background: #edf2fb;
+  padding: 0.25rem;
+  gap: 0.25rem;
+  align-self: flex-start;
+}
+.auth-toggle button {
+  border: none;
+  background: transparent;
+  color: #4267b2;
+  font-weight: 600;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.auth-toggle button.active {
   background: #1976d2;
   color: #fff;
-  border: none;
-  border-radius: 4px;
+  box-shadow: 0 6px 14px rgba(25, 118, 210, 0.32);
+}
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+.auth-form label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: #3d4b69;
+}
+.auth-form span {
+  font-weight: 600;
+}
+.auth-form input,
+.auth-form textarea {
+  width: 100%;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid #b3c6e6;
+  border-radius: 10px;
   font-size: 1rem;
-  font-weight: bold;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  resize: vertical;
+}
+.auth-form input:focus,
+.auth-form textarea:focus {
+  outline: none;
+  border-color: #1976d2;
+  box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.15);
+}
+.auth-form .primary,
+.login-container .primary {
+  width: 100%;
+  padding: 0.8rem;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #1976d2, #42a5f5);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
   cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.auth-form .primary:hover:enabled,
+.login-container .primary:hover:enabled {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(25, 118, 210, 0.26);
+}
+.auth-form .primary:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+.message {
+  border-radius: 12px;
+  padding: 0.8rem 1rem;
+  font-size: 0.95rem;
+}
+.message.success {
+  background: #e6f4ea;
+  color: #1b5e20;
+}
+.message.error {
+  background: #fdecea;
+  color: #c62828;
 }
 .login-tip {
-  color: #888;
-  font-size: 0.95rem;
-  margin-top: 1rem;
+  color: #6b7b93;
+  font-size: 0.92rem;
+  margin: 0.35rem 0 0;
+}
+.auth-footer {
+  display: grid;
+  gap: 0.4rem;
+}
+.link-button {
+  border: none;
+  background: none;
+  color: #1976d2;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 0.35rem;
+}
+.link-button:hover {
+  text-decoration: underline;
+}
+.guest-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: flex-start;
+}
+.guest-profile-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(25, 118, 210, 0.1);
+  padding: 2rem;
+  display: grid;
+  gap: 1.2rem;
+}
+.guest-profile-card dl {
+  display: grid;
+  gap: 0.7rem;
+}
+.guest-profile-card dt {
+  font-size: 0.9rem;
+  color: #6b7b93;
+}
+.guest-profile-card dd {
+  margin: 0.2rem 0 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #0d47a1;
+}
+.guest-perks {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.45rem;
+  color: #3d4b69;
+}
+.guest-post-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(25, 118, 210, 0.1);
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+.guest-drafts {
+  display: grid;
+  gap: 1rem;
+}
+.guest-post-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+.guest-post-list li {
+  padding: 1rem 1.2rem;
+  border-radius: 12px;
+  background: #f7f9fc;
+  display: grid;
+  gap: 0.6rem;
+}
+.guest-post-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: #0d47a1;
+}
+.guest-post-head time {
+  font-size: 0.85rem;
+  color: #6b7b93;
+}
+.guest-post-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+.guest-post-actions .link-button {
+  margin-left: 0;
 }
 @media (max-width: 700px) {
   main {
@@ -184,5 +399,15 @@ footer {
   }
   nav {
     margin-top: 0.5rem;
+  }
+  .auth-layout {
+    margin: 2rem 0;
+    grid-template-columns: 1fr;
+  }
+  .auth-hero {
+    padding: 2rem 1.75rem;
+  }
+  .login-container {
+    padding: 2rem 1.6rem;
   }
 }

--- a/src/app/guest/page.tsx
+++ b/src/app/guest/page.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import NavClient from "../../components/NavClient";
-import AccountClient from "../../components/AccountClient";
+import GuestExperience from "../../components/GuestExperience";
 
-export default function AccountPage() {
+export default function GuestPage() {
   return (
     <main>
       <header>
@@ -18,8 +18,7 @@ export default function AccountPage() {
         />
       </header>
       <section>
-        <h2>账号</h2>
-        <AccountClient />
+        <GuestExperience />
       </section>
     </main>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,8 +2,21 @@ import LoginForm from "../../components/LoginForm";
 
 export default function LoginPage() {
   return (
-    <main>
-      <LoginForm />
+    <main className="auth-layout">
+      <section className="auth-hero">
+        <h1>欢迎回到论坛</h1>
+        <p>
+          在这里结识志同道合的伙伴、分享你的灵感、加入热门派别。无论是技术探讨还是生活闲聊，都能找到属于自己的角落。
+        </p>
+        <ul>
+          <li>使用邮箱或用户名即可快速登录</li>
+          <li>一键切换注册，立即创建你的专属身份</li>
+          <li>支持移动端访问，随时随地继续讨论</li>
+        </ul>
+      </section>
+      <section className="auth-panel">
+        <LoginForm />
+      </section>
     </main>
   );
 }

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -12,6 +12,7 @@ export default function MePage() {
             { href: "/#hot", label: "热帖" },
             { href: "/factions", label: "热门派别" },
             { href: "/ranking", label: "用户排行" },
+            { href: "/guest", label: "游客体验" },
           ]}
           loginHref="/login"
         />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ export default function HomePage() {
             { href: "#hot", label: "热帖" },
             { href: "/factions", label: "热门派别" },
             { href: "/ranking", label: "用户排行" },
+            { href: "/guest", label: "游客体验" },
           ]}
           loginHref="/login"
         />

--- a/src/app/posts/new/page.tsx
+++ b/src/app/posts/new/page.tsx
@@ -12,6 +12,7 @@ export default function NewPostPage() {
             { href: "/#hot", label: "热帖" },
             { href: "/factions", label: "热门派别" },
             { href: "/ranking", label: "用户排行" },
+            { href: "/guest", label: "游客体验" },
           ]}
           loginHref="/login"
         />

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -29,6 +29,7 @@ export default function RankingPage() {
             { href: "/#hot", label: "热帖" },
             { href: "/factions", label: "热门派别" },
             { href: "/ranking", label: "用户排行" },
+            { href: "/guest", label: "游客体验" },
           ]}
           loginHref="/login"
         />

--- a/src/components/AccountClient.tsx
+++ b/src/components/AccountClient.tsx
@@ -27,7 +27,7 @@ export default function AccountClient() {
     <div className="login-container">
       <h2>我的账号</h2>
       <p className="login-tip">当前邮箱：{email}</p>
-      <button onClick={signOut} style={{ width: "95%", padding: ".7rem" }}>
+      <button onClick={signOut} className="primary">
         退出登录
       </button>
     </div>

--- a/src/components/GuestExperience.tsx
+++ b/src/components/GuestExperience.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type GuestPost = {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+};
+
+const STORAGE_KEY = "guest-posts";
+
+type GuestFeedback = { type: "success" | "error"; text: string };
+
+const createId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export default function GuestExperience() {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [posts, setPosts] = useState<GuestPost[]>([]);
+  const [feedback, setFeedback] = useState<GuestFeedback | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    try {
+      const parsed = JSON.parse(saved) as GuestPost[];
+      setPosts(parsed);
+    } catch (error) {
+      console.warn("Failed to parse guest posts", error);
+    }
+  }, []);
+
+  const persist = useCallback((nextPosts: GuestPost[]) => {
+    setPosts(nextPosts);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextPosts));
+    }
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedTitle = title.trim();
+    const trimmedContent = content.trim();
+    if (!trimmedTitle || !trimmedContent) {
+      setFeedback({ type: "error", text: "请填写完整的标题和内容" });
+      return;
+    }
+
+    const nextPost: GuestPost = {
+      id: createId(),
+      title: trimmedTitle,
+      content: trimmedContent,
+      createdAt: new Date().toISOString(),
+    };
+
+    const nextPosts = [nextPost, ...posts];
+    persist(nextPosts);
+    setTitle("");
+    setContent("");
+    setFeedback({ type: "success", text: "已保存到本地，登录后即可正式发布到社区" });
+  };
+
+  const handleRemove = (id: string) => {
+    const nextPosts = posts.filter((post) => post.id !== id);
+    persist(nextPosts);
+  };
+
+  const stats = useMemo(() => {
+    if (!posts.length) return { total: 0, latest: "-" };
+    const latest = posts[0];
+    return {
+      total: posts.length,
+      latest: new Date(latest.createdAt).toLocaleString(),
+    };
+  }, [posts]);
+
+  return (
+    <div className="guest-layout">
+      <aside className="guest-profile-card">
+        <h2>游客个人页</h2>
+        <p className="login-tip">
+          游客模式同样可以浏览热门内容、收藏灵感，并提前撰写帖子草稿。完成注册后即可一键发布。
+        </p>
+        <dl>
+          <div>
+            <dt>草稿数量</dt>
+            <dd>{stats.total}</dd>
+          </div>
+          <div>
+            <dt>最近保存</dt>
+            <dd>{stats.latest}</dd>
+          </div>
+        </dl>
+        <ul className="guest-perks">
+          <li>随时保存灵感草稿，不怕丢失</li>
+          <li>浏览论坛精选板块</li>
+          <li>注册后自动同步草稿提醒</li>
+        </ul>
+      </aside>
+
+      <section className="guest-post-card">
+        <h3>游客发帖体验</h3>
+        <p className="login-tip">
+          先把想说的话记录下来吧，内容会安全保存在你的浏览器中。
+        </p>
+        {feedback && <div className={`message ${feedback.type}`}>{feedback.text}</div>}
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <label>
+            <span>帖子标题</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="例如：我对 AI 与社会的看法"
+              required
+              maxLength={80}
+            />
+          </label>
+          <label>
+            <span>正文内容</span>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="记录灵感、提问或分享故事..."
+              required
+              rows={6}
+            />
+          </label>
+          <button type="submit" className="primary">
+            保存草稿
+          </button>
+        </form>
+
+        <div className="guest-drafts">
+          <h4>本地草稿</h4>
+          {!posts.length && <p className="login-tip">暂无草稿，先写一篇试试吧！</p>}
+          {posts.length > 0 && (
+            <ul className="guest-post-list">
+              {posts.map((post) => (
+                <li key={post.id}>
+                  <div className="guest-post-head">
+                    <strong>{post.title}</strong>
+                    <time>{new Date(post.createdAt).toLocaleString()}</time>
+                  </div>
+                  <p>{post.content}</p>
+                  <div className="guest-post-actions">
+                    <button type="button" className="link-button" onClick={() => handleRemove(post.id)}>
+                      删除草稿
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "../lib/supabase/client";
+
+type Mode = "signin" | "signup";
+type Feedback = { type: "success" | "error"; text: string };
 
 export default function LoginForm() {
   const [identifier, setIdentifier] = useState(""); // 邮箱或用户名
@@ -10,23 +14,33 @@ export default function LoginForm() {
   const [username, setUsername] = useState(""); // 注册用用户名
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<"signin" | "signup">("signin");
-  const [message, setMessage] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>("signin");
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
   const router = useRouter();
+
+  const switchMode = (nextMode: Mode) => {
+    setMode(nextMode);
+    setIdentifier("");
+    setEmail("");
+    setUsername("");
+    setPassword("");
+    setFeedback(null);
+  };
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    setMessage(null);
+    setFeedback(null);
     try {
       if (mode === "signin") {
         // 支持邮箱或用户名登录
-        let emailToUse = identifier;
-        if (!identifier.includes("@")) {
+        let emailToUse = identifier.trim();
+        if (!emailToUse) throw new Error("请输入邮箱或用户名");
+        if (!emailToUse.includes("@")) {
           const { data: prof, error: qErr } = await supabase
             .from("profiles")
             .select("email")
-            .eq("username", identifier)
+            .eq("username", emailToUse)
             .maybeSingle();
           if (qErr) throw qErr;
           if (!prof?.email) throw new Error("未找到该用户名");
@@ -35,89 +49,128 @@ export default function LoginForm() {
 
         const { error } = await supabase.auth.signInWithPassword({ email: emailToUse, password });
         if (error) throw error;
+        setFeedback({ type: "success", text: "登录成功，正在跳转..." });
         router.replace("/");
-        setMessage("登录成功");
       } else {
         // 注册：收集邮箱 + 用户名 + 密码
         if (!username.trim()) throw new Error("请填写用户名");
-        const { data, error } = await supabase.auth.signUp({ email, password });
+        const { data, error } = await supabase.auth.signUp({ email: email.trim(), password });
         if (error) throw error;
 
         // 在 profiles 表中插入用户名
         if (data.user?.id) {
           const { error: profileError } = await supabase.from("profiles").insert({
             user_id: data.user.id,
-            username,
-            email,
+            username: username.trim(),
+            email: email.trim(),
           });
           if (profileError) throw profileError;
         }
 
-        setMessage("注册成功，请检查邮箱确认！");
+        setFeedback({ type: "success", text: "注册成功，请检查邮箱确认！" });
       }
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : "发生未知错误";
-      setMessage(errorMessage);
+      setFeedback({ type: "error", text: errorMessage });
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="login-container">
-      <h1>{mode === "signin" ? "登录" : "注册"}</h1>
-      {message && <div className="message">{message}</div>}
-      <form onSubmit={onSubmit}>
+    <div className="login-container" role="region" aria-labelledby="auth-title">
+      <div className="auth-toggle" role="tablist" aria-label="登录或注册">
+        <button
+          type="button"
+          className={mode === "signin" ? "active" : undefined}
+          onClick={() => switchMode("signin")}
+          aria-pressed={mode === "signin"}
+        >
+          登录
+        </button>
+        <button
+          type="button"
+          className={mode === "signup" ? "active" : undefined}
+          onClick={() => switchMode("signup")}
+          aria-pressed={mode === "signup"}
+        >
+          注册
+        </button>
+      </div>
+      <h1 id="auth-title">{mode === "signin" ? "欢迎回来" : "注册新账号"}</h1>
+      <p className="login-subtitle">
+        {mode === "signin" ? "输入账号信息，即刻开启今日的讨论。" : "填写信息，加入热闹的论坛社区。"}
+      </p>
+      {feedback && <div className={`message ${feedback.type}`}>{feedback.text}</div>}
+      <form className="auth-form" onSubmit={onSubmit}>
         {mode === "signin" ? (
-          <input
-            type="text"
-            placeholder="邮箱或用户名"
-            value={identifier}
-            onChange={(e) => setIdentifier(e.target.value)}
-            required
-          />
-        ) : (
-          <>
-            <input
-              type="email"
-              placeholder="邮箱"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
+          <label>
+            <span>邮箱或用户名</span>
             <input
               type="text"
-              placeholder="用户名"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              placeholder="your@email.com 或昵称"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
               required
+              autoComplete="username"
             />
+          </label>
+        ) : (
+          <>
+            <label>
+              <span>邮箱</span>
+              <input
+                type="email"
+                placeholder="用于接收验证邮件"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+              />
+            </label>
+            <label>
+              <span>用户名</span>
+              <input
+                type="text"
+                placeholder="社区中的展示名称"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                autoComplete="nickname"
+              />
+            </label>
           </>
         )}
-        <input
-          type="password"
-          placeholder="密码"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-        <button type="submit" disabled={loading}>
+        <label>
+          <span>密码</span>
+          <input
+            type="password"
+            placeholder="至少 6 位字符"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoComplete={mode === "signin" ? "current-password" : "new-password"}
+          />
+        </label>
+        <button type="submit" className="primary" disabled={loading}>
           {loading ? "处理中..." : mode === "signin" ? "登录" : "注册"}
         </button>
       </form>
-      <p className="login-tip">
-        {mode === "signin" ? (
-          <>
-            尚未注册？
-            <a href="#" onClick={() => setMode("signup")}>去注册</a>
-          </>
-        ) : (
-          <>
-            已有账号？
-            <a href="#" onClick={() => setMode("signin")}>去登录</a>
-          </>
-        )}
-      </p>
+      <div className="auth-footer">
+        <p className="login-tip">
+          {mode === "signin" ? "还没有账号？" : "已经有账号了？"}
+          <button
+            type="button"
+            onClick={() => switchMode(mode === "signin" ? "signup" : "signin")}
+            className="link-button"
+          >
+            {mode === "signin" ? "立即注册" : "去登录"}
+          </button>
+        </p>
+        <p className="login-tip">
+          还在犹豫？<Link href="/guest">先以游客身份体验社区</Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/PostForm.tsx
+++ b/src/components/PostForm.tsx
@@ -54,7 +54,7 @@ export default function PostForm() {
   return (
     <div className="login-container" style={{ maxWidth: 600 }}>
       <h2>发布新帖子</h2>
-      <form onSubmit={submit}>
+      <form className="auth-form" onSubmit={submit}>
         <input
           type="text"
           placeholder="标题"
@@ -67,9 +67,9 @@ export default function PostForm() {
           value={content}
           onChange={(e) => setContent(e.target.value)}
           required
-          style={{ width: "95%", height: 160, padding: ".7rem", border: "1px solid #b3c6e6", borderRadius: 4 }}
+          style={{ width: "100%", height: 160, padding: ".7rem", border: "1px solid #b3c6e6", borderRadius: 10 }}
         />
-        <button type="submit" disabled={loading}>
+        <button type="submit" className="primary" disabled={loading}>
           {loading ? "发布中..." : "发布"}
         </button>
       </form>

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,9 +1,6 @@
 export default function LoginPage() {
   return (
     <main>
-      {/* 引入全局样式 */}
-      <link rel="stylesheet" href="/css/style.css" />
-      
       <div className="login-container">
         <h2>用户登录</h2>
         <form id="login-form">


### PR DESCRIPTION
## Summary
- redesign the login page with a split hero + form layout and refreshed styling for the authentication flow
- introduce a guest experience page with a local draft posting sandbox and link it from the global navigation
- centralize updated form/button styles across account and posting components for a cohesive look

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd55861a4c8328936636eeb2e70fcf