### PR TITLE
Guard base path env and simplify Next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,23 +1,28 @@
 import type { NextConfig } from "next";
 
-const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH?.trim();
-const normalizedBasePath =
-  rawBasePath && rawBasePath !== "/"
+let rawBasePath: string | undefined;
 
-    ? `/${rawBasePath.replace(/^\/+|\/+$/g, "")}`
-    : "";
+if (typeof process.env.NEXT_PUBLIC_BASE_PATH === "string") {
+  const envValue = process.env.NEXT_PUBLIC_BASE_PATH.trim();
 
-const nextConfig: NextConfig = {
+  if (envValue.length > 0) {
+    rawBasePath = envValue;
+  }
+}
 
-    ? rawBasePath.replace(/\/+$/, "")
-    : "";
+let normalizedBasePath = "";
 
-  ...(normalizedBasePath
-    ? {
-        basePath: normalizedBasePath,
-        assetPrefix: `${normalizedBasePath}/`,
-      }
-    : {}),
-};
+if (typeof rawBasePath === "string") {
+  if (rawBasePath !== "/") {
+    normalizedBasePath = `/${rawBasePath.replace(/^\/+|\/+$/g, "")}`;
+  }
+}
+
+const nextConfig: NextConfig = {};
+
+if (normalizedBasePath) {
+  nextConfig.basePath = normalizedBasePath;
+  nextConfig.assetPrefix = `${normalizedBasePath}/`;
+}
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- guard `NEXT_PUBLIC_BASE_PATH` with standard conditionals before trimming and normalizing the value
- keep the existing normalization logic while constructing the Next.js config as a plain object
- assign `basePath` and `assetPrefix` only when a normalized base path is present

## Testing
- npm run lint
- npm run build *(fails: next/font fetch for Geist/Geist Mono requires external network)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6bc92da483288f31b2cfed36aff6