### PR TITLE
Harden Supabase client usage and normalize post authors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', Arial, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', 'Menlo', 'Consolas', monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "论坛站点",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-CN">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/src/components/AccountClient.tsx
+++ b/src/components/AccountClient.tsx
@@ -1,26 +1,44 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { supabase } from "../lib/supabase/client";
+import { useEffect, useMemo, useState } from "react";
+import { getBrowserSupabaseClient } from "../lib/supabase/client";
 
 export default function AccountClient() {
   const [email, setEmail] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  const supabase = useMemo(() => {
+    try {
+      return getBrowserSupabaseClient();
+    } catch (error) {
+      console.error("Supabase client unavailable", error);
+      return null;
+    }
+  }, []);
 
   useEffect(() => {
+    if (!supabase) {
+      setClientError("Supabase 未配置，无法加载账号信息");
+      setLoading(false);
+      return;
+    }
+
     (async () => {
       const { data } = await supabase.auth.getUser();
       setEmail(data.user?.email ?? null);
       setLoading(false);
     })();
-  }, []);
+  }, [supabase]);
 
   const signOut = async () => {
+    if (!supabase) return;
     await supabase.auth.signOut();
     location.href = "/";
   };
 
   if (loading) return <p className="login-tip">加载中...</p>;
+  if (clientError) return <p className="login-tip">{clientError}</p>;
   if (!email) return <p className="login-tip">未登录</p>;
 
   return (

--- a/src/components/PostForm.tsx
+++ b/src/components/PostForm.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { supabase } from "../lib/supabase/client";
+import { getBrowserSupabaseClient } from "../lib/supabase/client";
 
 export default function PostForm() {
   const router = useRouter();
@@ -11,9 +11,24 @@ export default function PostForm() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  const supabase = useMemo(() => {
+    try {
+      return getBrowserSupabaseClient();
+    } catch (error) {
+      console.error("Supabase client unavailable", error);
+      return null;
+    }
+  }, []);
 
   // 若未登录，引导到登录页
   useEffect(() => {
+    if (!supabase) {
+      setClientError("Supabase 未配置，暂时无法发帖");
+      return;
+    }
+
     (async () => {
       const { data } = await supabase.auth.getUser();
       if (!data.user) {
@@ -22,10 +37,14 @@ export default function PostForm() {
       }
       setReady(true);
     })();
-  }, [router]);
+  }, [router, supabase]);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!supabase) {
+      setMessage("环境未完成配置，无法发布帖子");
+      return;
+    }
     setLoading(true);
     setMessage(null);
     try {
@@ -50,6 +69,15 @@ export default function PostForm() {
   };
 
   if (!ready) return null;
+
+  if (clientError) {
+    return (
+      <div className="login-container" style={{ maxWidth: 600 }}>
+        <h2>发布新帖子</h2>
+        <p className="login-tip">{clientError}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="login-container" style={{ maxWidth: 600 }}>

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,50 @@
+export type Profile = { username: string | null; email: string | null };
+
+export type ProfileRelation = Profile | Profile[] | null;
+
+export type PostRow = {
+  id: string;
+  title: string;
+  content: string;
+  created_at: string;
+  profiles: ProfileRelation;
+};
+
+export type Post = Omit<PostRow, "profiles"> & { profiles: Profile | null };
+
+export function normalizeProfileRelation(relation: ProfileRelation): Profile | null {
+  if (!relation) return null;
+  if (Array.isArray(relation)) {
+    return relation[0] ?? null;
+  }
+  return relation;
+}
+
+export function normalizePostRow(row: PostRow | null): Post | null {
+  if (!row) return null;
+  return {
+    ...row,
+    profiles: normalizeProfileRelation(row.profiles),
+  };
+}
+
+export function normalizePostRows(rows: PostRow[] | null | undefined): Post[] {
+  if (!rows) return [];
+  return rows.map((row) => ({
+    ...row,
+    profiles: normalizeProfileRelation(row.profiles),
+  }));
+}
+
+export function formatPostAuthor(post: Pick<Post, "profiles">): string {
+  const username = post.profiles?.username ?? null;
+  if (username) return username;
+  const email = post.profiles?.email ?? null;
+  if (email) {
+    const [localPart] = email.split("@");
+    if (localPart) {
+      return localPart;
+    }
+  }
+  return "匿名用户";
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,11 +1,19 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!url || !anon) {
-  // Soft guard to help during dev; avoids crashing at import time in prod
+let client: SupabaseClient | null = null;
+
+if (url && anon) {
+  client = createClient(url, anon);
+} else {
   console.warn("Supabase env missing: set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY");
 }
 
-export const supabase = createClient(url ?? "", anon ?? "");
+export function getBrowserSupabaseClient(): SupabaseClient {
+  if (!client) {
+    throw new Error("Supabase client is not configured. Ensure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are set.");
+  }
+  return client;
+}


### PR DESCRIPTION
## Summary
- add shared helpers to normalize Supabase post profile relations and reuse a single author formatter across listing and detail pages
- lazy-initialize the browser Supabase client and update all interactive components to gracefully handle missing environment configuration with helpful feedback
- drop the remote Geist font dependency so production builds succeed without external downloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd7398f0d083289525b843474c437f