### PR TITLE
Fix HomePage syntax error

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,13 +48,6 @@ async function fetchLatestPosts(): Promise<{ posts: Post[]; error: string | null
 }
 
 
-function formatAuthor(post: Post) {
-  const username = post.profiles?.username ?? null;
-  const email = post.profiles?.email ?? null;
-  if (username) return username;
-  if (email) return email.split("@")[0];
-  return "匿名用户";
-
 function InfoCard({ item }: { item: Item }) {
   return (
     <div className="info-card">


### PR DESCRIPTION
## Summary
- remove unused and unterminated `formatAuthor` helper from the home page component to restore valid TypeScript syntax

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce09cbfdcc8328af94a4276d808c85