### PR TITLE
Update profiles table schema

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -27,27 +27,30 @@ using (auth.uid() = user_id);
 -- Run once; if bucket exists this will error, you can ignore or create manually
 -- select storage.create_bucket('avatars', true, 'public');
 
--- Profiles table for username-based login lookup
 create table if not exists public.profiles (
   user_id uuid primary key references auth.users(id) on delete cascade,
-  username text unique not null check (length(trim(username)) >= 3),
-  email text unique not null,
+  username text unique,
+  avatar_url text,
+  bio text,
   created_at timestamp with time zone not null default now()
 );
 
 alter table public.profiles enable row level security;
 
--- Read: allow selecting username/email pairs (simple demo; consider restricting in prod)
-create policy if not exists "profiles_select_all"
+-- Read: allow selecting profile information (consider restricting in production)
+drop policy if exists profiles_select_all on public.profiles;
+create policy profiles_select_all
 on public.profiles for select
 using (true);
 
 -- Insert/Update: only the owner can write their row
-create policy if not exists "profiles_insert_own"
+drop policy if exists profiles_insert_own on public.profiles;
+create policy profiles_insert_own
 on public.profiles for insert
 with check (auth.uid() = user_id);
 
-create policy if not exists "profiles_update_own"
+drop policy if exists profiles_update_own on public.profiles;
+create policy profiles_update_own
 on public.profiles for update
 using (auth.uid() = user_id)
 with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- align the `public.profiles` table with the desired schema by dropping the email column and adding avatar and bio fields
- refresh the related row level security policies so they can be reapplied safely in subsequent migrations

## Testing
- not run (schema change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce3a0634948328805b1650cf50b717