### PR TITLE
Fix newsbot script path and documentation

### DIFF
--- a/NEWSBOT_README.md
+++ b/NEWSBOT_README.md
@@ -37,6 +37,7 @@ src/
 │   └── SystemMonitor.tsx    # 系统状态监控组件
 │
 ├── lib/
+│   ├── enhanced-newsbot.py  # API 调用的增强版新闻机器人脚本
 │   ├── newsbot.py           # 核心新闻机器人库（Python集成）
 │   ├── scheduler.ts         # 任务调度系统
 │   └── newsbot-config.ts    # 配置管理系统
@@ -104,6 +105,8 @@ NEWSBOT_USER_ID=newsbot_account_id
 ```bash
 pip install selenium beautifulsoup4 openai requests supabase
 ```
+
+> 📌 **重要**：Next.js API 会从 `src/lib/enhanced-newsbot.py` 调用新闻机器人脚本，请确保部署时该文件位于此路径。
 
 ## 🎛 使用指南
 

--- a/src/app/api/newsbot/route.ts
+++ b/src/app/api/newsbot/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSupabaseClient } from "../../../lib/supabase/server";
 import { spawn } from 'child_process';
 import path from 'path';
+import { existsSync } from 'fs';
 
 export const runtime = 'nodejs'
 export const maxDuration = 300
@@ -17,7 +18,16 @@ export async function GET(request: NextRequest): Promise<Response> {
     // 执行Python新闻爬虫脚本
     return new Promise<Response>((resolve) => {
       const pythonPath = process.env.PYTHON_PATH || 'python'
-      const scriptPath = path.join(process.cwd(), 'enhanced-newsbot.py')
+      const scriptPath = path.join(process.cwd(), 'src', 'lib', 'enhanced-newsbot.py')
+
+      if (!existsSync(scriptPath)) {
+        console.error('Python script not found at path:', scriptPath)
+        resolve(NextResponse.json({
+          success: false,
+          error: '新闻机器人脚本不存在',
+        }, { status: 500 }))
+        return
+      }
       
       const python = spawn(pythonPath, [scriptPath])
       


### PR DESCRIPTION
## Summary
- update the newsbot API to execute the enhanced Python script from `src/lib/enhanced-newsbot.py` and guard against missing files
- document the required script location in the NEWSBOT README to keep deployment instructions accurate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2544d4e0083288ff377358b4b96df