### PR TITLE
Fix dependency detection for BeautifulSoup

### DIFF
--- a/test_newsbot.py
+++ b/test_newsbot.py
@@ -92,9 +92,14 @@ def check_dependencies():
     
     missing_packages = []
     
+    package_module_map = {
+        'beautifulsoup4': 'bs4',
+    }
+
     for package in required_packages:
+        module_name = package_module_map.get(package, package.replace('-', '_'))
         try:
-            __import__(package.replace('-', '_').replace('4', ''))
+            __import__(module_name)
             print(f"   ✅ {package}")
         except ImportError:
             print(f"   ❌ {package} (缺失)")


### PR DESCRIPTION
## Summary
- adjust the dependency checker to map beautifulsoup4 to the correct import name bs4 before attempting to import

## Testing
- PYTHONPATH=/tmp/py_stubs python test_newsbot.py

------
https://chatgpt.com/codex/tasks/task_e_68d26b5f72dc83289c3bbf6dbd7a0ff4